### PR TITLE
Support pyppmd 1.0.0: Ppmd8Decoder endmark arg was removed

### DIFF
--- a/zipfile_ppmd/_zipfile.py
+++ b/zipfile_ppmd/_zipfile.py
@@ -64,7 +64,7 @@ class PPMDDecompressor(object):
             sasize = ((prop&0x0ff0)>>4)+1
             restore_method = (prop&0xf000)>>12
 
-            self._decomp = pyppmd.Ppmd8Decoder(order, sasize<<20, restore_method=restore_method, endmark=False)
+            self._decomp = pyppmd.Ppmd8Decoder(order, sasize<<20, restore_method=restore_method)
             data = self._unconsumed[2:]
             del self._unconsumed
 


### PR DESCRIPTION
Hi, very useful package. But after installing from pypi, which installed the latest pyppmd 1.0.0 as a dependency, I found that zipfile-ppmd couldn't read zips due to a change to pyppm.Ppmd8Decoder().

Note that I didn't bump the version number.